### PR TITLE
MinkBrowserKitDriver initializes without a request

### DIFF
--- a/src/Behat/Mink/Driver/BrowserKitDriver.php
+++ b/src/Behat/Mink/Driver/BrowserKitDriver.php
@@ -145,7 +145,13 @@ class BrowserKitDriver extends CoreDriver
      */
     public function getCurrentUrl()
     {
-        return $this->client->getRequest()->getUri();
+        $request = $this->client->getRequest();
+
+        if ($request == null) {
+            throw new DriverException('Current URL not set. Did you start the driver?');
+        }
+
+        return $request->getUri();
     }
 
     /**


### PR DESCRIPTION
Related to https://github.com/Behat/MinkBrowserKitDriver/issues/6

The problem seems to be that the webkit drivers initialize without an initial landing page. The javascript drivers (specifically referring to selenium2) seems to initialize with about:blank, thus giving them the ability to call getCurrentUrl() and getContent()...even though the results are blank documents and "about:blank".

I am not sure this is a problem to begin with, since your tests should start by putting your scenario in the correct state and at the correct location. I did however update the getCurrentUrl() function to throw a more helpful exception, instead of a fatal error.

I found that the getContent() method has already been fixed so that it throws a more presentable error.
