### PR TITLE
Functions for getting active window names.

### DIFF
--- a/src/Behat/Mink/Driver/BrowserKitDriver.php
+++ b/src/Behat/Mink/Driver/BrowserKitDriver.php
@@ -306,6 +306,26 @@ class BrowserKitDriver extends CoreDriver
     }
 
     /**
+     * Return the names of all open windows
+     *
+     * @return array    array of all open windows
+     */
+    public function getWindowNames()
+    {
+        throw new UnsupportedDriverActionException('Listing all window names is not supported by %s', $this);
+    }
+
+    /**
+     * Return the name of the currently active window
+     *
+     * @return string    the name of the current window
+     */
+    public function getWindowName()
+    {
+        throw new UnsupportedDriverActionException('Listing this window name is not supported by %s', $this);
+    }
+
+    /**
      * Finds elements with specified XPath query.
      *
      * @param string $xpath


### PR DESCRIPTION
Related to: https://github.com/Behat/Mink/pull/341

These are required changes to make the get window name functions to work with the Selenium 2 driver. Per https://github.com/Behat/MinkSelenium2Driver/pull/55.

This is just a simple function declaration to clear up an error.
# It allows the below functionality to work:

These changes add the ability to get the name of the currently open window AND an array of all open windows. This will be accompanied with contributions to the selenium 2 driver and the browserkit driver (the next thing I commit, already written though).

Originally discussed in the Google group for Behat, which can be found under: https://groups.google.com/d/msg/behat/QNhOuGHKEWI/pJG-2Ve_DT0J

My changes introduce two new functions that take advantage of some native functionality in Selenium to interface with multiple windows and discover the names of the active window and all open windows. My changes are based on the latest code in develop.

The use case I made this for is where a button on a web application I develop tests for has several situations where when you click an action button (in this case 'Withdraw") the action triggers a popup window which must be completed and submitted before the action will be finalized. So I needed to make it so that Behat could handle finding and switching to that open window.

The way I use it is I write a context called "iSwitchToPopup" that records to the object the current (main) window name. Then I write my normal BDD statements to complete the form and I call a second custom context called "iSwitchBackToOriginalWindow".

Now, as a quick side note, in my use case when you submit the form in the popup it closes that popup window. This will leave you in a window-limbo. The only action you can really successfully take is to switch back to the original window, otherwise it will throw various errors (since you are no longer focused on a window). Once switched back to main you will be able to continue as normal.
