### PR TITLE
Implements __clone() method for BrowserKitDriver

### DIFF
--- a/src/Behat/Mink/Driver/BrowserKitDriver.php
+++ b/src/Behat/Mink/Driver/BrowserKitDriver.php
@@ -50,6 +50,12 @@ class BrowserKitDriver extends CoreDriver
         $this->client->followRedirects(true);
     }
 
+    function __clone()
+    {
+        $this->client = clone $this->client;
+    }
+
+
     /**
      * Returns BrowserKit HTTP client instance.
      *


### PR DESCRIPTION
Implements a clone method that clones also the client instance and allows to use multiple sessions. This should be complementary of Behat/Mink#368 as described in Behat/Mink#270
