### PR TITLE
GetCurrentUrl() return null instead of fatal error

### DIFF
--- a/src/Behat/Mink/Driver/BrowserKitDriver.php
+++ b/src/Behat/Mink/Driver/BrowserKitDriver.php
@@ -145,7 +145,16 @@ class BrowserKitDriver extends CoreDriver
      */
     public function getCurrentUrl()
     {
-        return $this->client->getRequest()->getUri();
+        $request = $this->client->getRequest();
+
+        if ($request == null) {
+            // If no request exists, return the current
+            // URL as null instead of running into a
+            // "method on non-object" error.
+            return null;
+        }
+
+        return $request->getUri();
     }
 
     /**


### PR DESCRIPTION
Related to https://github.com/Behat/MinkBrowserKitDriver/pull/17. When a user calls `getCurrentUrl()` without having made a request yet. The function throws a fatal error complaining that `getRequest()` returns a non-object.

How To Replicate:
- Configure an @AfterStep event that prints out $this->getSession()->getCurrentUrl()
- Run the following scenario.

Scenario:
    Then print current URL

I know you wouldn't expect it to work since you haven't navigated anymore. However, I think it should still be handled "gracefully" instead of breaking execution...as there are legitimate cases for wanting to retrieve the current URL without knowing if any requests have been executed yet.
