### PR TITLE
Fix failure when using a base URL

### DIFF
--- a/src/Behat/Mink/Driver/BrowserKitDriver.php
+++ b/src/Behat/Mink/Driver/BrowserKitDriver.php
@@ -14,6 +14,7 @@ use Symfony\Component\DomCrawler\Field;
 use Symfony\Component\DomCrawler\Field\FormField;
 use Symfony\Component\DomCrawler\Form;
 use Symfony\Component\HttpFoundation\Response as HttpFoundationResponse;
+use Symfony\Component\HttpKernel\Client as HttpKernelClient;
 
 /*
  * This file is part of the Behat\Mink.
@@ -40,12 +41,17 @@ class BrowserKitDriver extends CoreDriver
     /**
      * Initializes BrowserKit driver.
      *
-     * @param Client $client BrowserKit client instance
+     * @param Client      $client  BrowserKit client instance
+     * @param string|null $baseUrl Base URL for HttpKernel clients
      */
-    public function __construct(Client $client = null)
+    public function __construct(Client $client = null, $baseUrl = null)
     {
         $this->client = $client;
         $this->client->followRedirects(true);
+
+        if ($baseUrl !== null && $client instanceof HttpKernelClient) {
+            $client->setServerParameter('SCRIPT_FILENAME', parse_url($baseUrl, PHP_URL_PATH));
+        }
     }
 
     /**

--- a/tests/Behat/Mink/Driver/BrowserKitDriverTest.php
+++ b/tests/Behat/Mink/Driver/BrowserKitDriverTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Behat\Mink\Driver;
 
 use Behat\Mink\Driver\BrowserKitDriver;
+use Behat\Mink\Session;
 use Symfony\Component\HttpKernel\Client;
 
 /**
@@ -22,5 +23,16 @@ class BrowserKitDriverTest extends HeadlessDriverTest
     protected function pathTo($path)
     {
         return 'http://localhost'.$path;
+    }
+
+    public function testBaseUrl()
+    {
+        $client = new Client(require(__DIR__.'/../../../app.php'));
+        $driver = new BrowserKitDriver($client, 'http://localhost/foo/');
+        $session = new Session($driver);
+
+        $session->visit('http://localhost/foo/index.php');
+        $this->assertEquals(200, $session->getStatusCode());
+        $this->assertEquals('http://localhost/foo/index.php', $session->getCurrentUrl());
     }
 }


### PR DESCRIPTION
The driver currently fails when using a base URL (see #9 and https://github.com/Behat/Symfony2Extension/issues/32).

The problem appears to be that `HttpFoundation\Request::prepareBaseUrl()` can't work out the correct answer. So for the base URL 'http://localhost/app/app_test.php' and the request 'http://localhost/app/app_test.php/foo', it returns '/' rather than '/app/app_test.php', leading the router to look for '/app/app_test.php/foo' rather than '/foo' (so every response is a 404).

This PR fakes a `$_SERVER["SCRIPT_FILENAME"]` variable by setting it to the path of the base URL, which is enough for `HttpFoundation\Request::prepareBaseUrl()` to work.

There doesn't seem to be any side effects of doing this (it's worked fine for the limited manual tests that I've done, and nothing outside the request in Symfony seems to use it). Alternatively, the front controller path could be used instead (though this is a little extra work for the end user).

Thoughts?

(Tests etc to come obviously!)
