### PR TITLE
getFormField multi elements if element does not have an id

### DIFF
--- a/src/Behat/Mink/Driver/BrowserKitDriver.php
+++ b/src/Behat/Mink/Driver/BrowserKitDriver.php
@@ -606,12 +606,22 @@ class BrowserKitDriver extends CoreDriver
         // we will access our element by name next, but that's not unique, so we need to know wich is ou element
         $elements = $this->getCrawler()->filterXPath('//*[@name=\''.$fieldNode->getAttribute('name').'\']');
         $position = 0;
-        if(count($elements) > 1) {
+         if(count($elements) > 1) {
             // more than one element contains this name !
-            // so we need to find the position of $fieldNode
+            // so we need to find the position of $fieldNode 
+            // based on field "id" or "value" if element does not have an id
             foreach($elements as $key => $element) {
-                if($element->getAttribute('id') == $fieldNode->getAttribute('id')) {
-                    $position = $key;
+             
+                $elementAttrib = $element->getAttribute('id');
+                $fieldNodeAttrib = $fieldNode->getAttribute('id');
+                
+                if($elementAttrib == "" && $fieldNodeAttrib == ""){
+                    $elementAttrib = $element->getAttribute('value');
+                    $fieldNodeAttrib = $fieldNode->getAttribute('value');
+                }
+                
+                if($elementAttrib == $fieldNodeAttrib) {
+                  $position = $key;
                 }
             }
         }


### PR DESCRIPTION
I've found and issue while trying to tick a checkbox created by Zend Framework 2, using its Multicheckbox element. It produces n input fields all with the same name foo[], and there isn't an easy way to set an id for each of them. When I try to tick one or more of these elements both  the $element->getAttribute('id') and the $fieldNode->getAttribute('id') methods return the same empty string. As a result, only the last checkbox is checked. Applying the comparison to the value instead of the id when it is not present, checkboxes work properly.
