### PR TITLE
Use @dev versions of dependencies during development

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 
     "require": {
         "php":                  ">=5.3.1",
-        "behat/mink":           "~1.5.0",
+        "behat/mink":           "~1.5.0@dev",
         "symfony/browser-kit":  "~2.0",
         "symfony/dom-crawler":  "~2.0"
     },


### PR DESCRIPTION
I'm proposing to use @dev versions of dependencies from Behat repos to ensure all the latest dev patches are available to the drivers during their development and testing.

If Travis tests are failing, then might be because some of Mink's @dev version tests weren't properly tested with headless non-js supported drivers.
