### PR TITLE
Stable missing attribute handling

### DIFF
--- a/src/Behat/Mink/Driver/BrowserKitDriver.php
+++ b/src/Behat/Mink/Driver/BrowserKitDriver.php
@@ -380,9 +380,13 @@ class BrowserKitDriver extends CoreDriver
      */
     public function getAttribute($xpath, $name)
     {
-        $value = $this->getCrawler()->filterXPath($xpath)->eq(0)->attr($name);
+        $node = $this->getCrawler()->filterXPath($xpath)->eq(0);
 
-        return '' !== $value ? $value : null;
+        if ($this->getCrawlerNode($node)->hasAttribute($name)) {
+            return $node->attr($name);
+        }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
Due bug in `DomCrawler` it returns empty string for following cases:
- when attribute is missing
- when attribute is present and has empty value

Because of this there were no way to know if attribute is really missing and a workaround code in `getAttribute` method of a driver considered present attributes with empty values as missing.

To solve this problem in JavaScript-enabled drivers I've used `getAttribute` JavaScript method (see https://github.com/Behat/MinkSelenium2Driver/pull/89, https://github.com/Behat/MinkSeleniumDriver/pull/18, https://github.com/Behat/SahiClient/pull/12).

Here I've needed to inspect associated `DOMNode` to see if an attribute is in fact present and only then return it's value.

Related to https://github.com/Behat/Mink/issues/389.
