### PR TITLE
Clean exceptions

### DIFF
--- a/src/Behat/Mink/Driver/BrowserKitDriver.php
+++ b/src/Behat/Mink/Driver/BrowserKitDriver.php
@@ -732,8 +732,7 @@ class BrowserKitDriver extends CoreDriver
 
         // find form button
         if (null === $buttonNode = $this->findFormButton($formNode)) {
-            $message = 'form submit button for field with xpath "' . $xpath . '"';
-            throw new ElementNotFoundException($this->session, $message);
+            throw new ElementNotFoundException($this->session, 'form submit button for field', 'xpath', $xpath);
         }
 
         $this->forms[$formId] = new Form($buttonNode, $this->getCurrentUrl());


### PR DESCRIPTION
Mink has a DriverException for exceptions thrown by drivers when they cannot perform the action they are asked, but BrowserKitDriver was using a LogicException in some cases and a DriverException in others
