### PR TITLE
Changed the visibility of the BC layer implementation to private

### DIFF
--- a/src/Behat/Mink/Driver/BrowserKitDriver.php
+++ b/src/Behat/Mink/Driver/BrowserKitDriver.php
@@ -644,7 +644,7 @@ class BrowserKitDriver extends CoreDriver
      *
      * @throws \LogicException If the response cannot be converted to a BrowserKit response
      */
-    protected function convertImplementationResponse($response)
+    private function convertImplementationResponse($response)
     {
         if ($response instanceof Response) {
             return $response;


### PR DESCRIPTION
There is no reason to make this method protected, and it will disappear in 2.x (where I dropped the support of old Symfony versions)
This method is not yet part of any release (it has been merged 6 hours ago), so there is no BC break.
