### PR TITLE
Improved the Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,19 @@
 language: php
 
-php: [5.3, 5.4, 5.5, hhvm]
+php: [5.3, 5.4, 5.5, 5.6, hhvm]
 
 matrix:
   allow_failures:
     - php: hhvm
   fast_finish: true
-  exclude:
-    - php: hhvm
+  include:
+    - php: 5.5
       env: SYMFONY_VERSION='2.3.*'
-
-env:
-  - SYMFONY_VERSION='2.3.*'
-  - SYMFONY_VERSION='2.4.*'
+    - php: 5.5
+      env: SYMFONY_VERSION='2.5.*@dev'
 
 before_script:
-  - composer require -n --no-update symfony/symfony=$SYMFONY_VERSION
+  - sh -c 'if [ "$SYMFONY_VERSION" != "" ]; then composer require -n --no-update symfony/symfony=$SYMFONY_VERSION; fi;'
   - composer install -n --prefer-source
 
 script: phpunit -v --coverage-clover=coverage.clover


### PR DESCRIPTION
Tests again the different PHP versions are now resolving the composer dependencies unmodified. Tests again other Symfony versions are runing only for PHP 5.5 to limit the number of jobs in the matrix.
Testing against PHP 5.6 and against Symfony 2.5@dev has been added.

This is based on the setup used for MinkExtension since months (and applied since on other repos)
