### PR TITLE
Changed the visibility of some helper methods to private

### DIFF
--- a/src/Behat/Mink/Driver/BrowserKitDriver.php
+++ b/src/Behat/Mink/Driver/BrowserKitDriver.php
@@ -278,7 +278,7 @@ class BrowserKitDriver extends CoreDriver
      *
      * @param string $name Cookie name.
      */
-    protected function deleteCookie($name)
+    private function deleteCookie($name)
     {
         $path = $this->getCookiePath();
         $jar = $this->client->getCookieJar();
@@ -297,7 +297,7 @@ class BrowserKitDriver extends CoreDriver
      *
      * @return string
      */
-    protected function getCookiePath()
+    private function getCookiePath()
     {
         $path = dirname(parse_url($this->getCurrentUrl(), PHP_URL_PATH));
 


### PR DESCRIPTION
These 2 methods are not meant to be extension points of the class, and they have not yet been released (they don't exist yet in 1.1.0). So making them private is a better choice
