### PR TITLE
Improve driver reset

### DIFF
--- a/src/Behat/Mink/Driver/BrowserKitDriver.php
+++ b/src/Behat/Mink/Driver/BrowserKitDriver.php
@@ -926,7 +926,7 @@ class BrowserKitDriver extends CoreDriver
         $crawler = $this->client->getCrawler();
 
         if (null === $crawler) {
-            throw new DriverException('Crawler can\'t be initialized. Did you started driver?');
+            throw new DriverException('Unable to access the response content before visiting a page');
         }
 
         return $crawler;


### PR DESCRIPTION
This improves the driver reset by resetting the history as well (it was already the case in 1.1 but was changed because of the cookie test requiring to allow reloading). this is now possible thanks to https://github.com/Behat/Mink/pull/511
