### PR TITLE
Fixed the constructor typehint for the client

### DIFF
--- a/src/Behat/Mink/Driver/BrowserKitDriver.php
+++ b/src/Behat/Mink/Driver/BrowserKitDriver.php
@@ -49,7 +49,7 @@ class BrowserKitDriver extends CoreDriver
      * @param Client      $client  BrowserKit client instance
      * @param string|null $baseUrl Base URL for HttpKernel clients
      */
-    public function __construct(Client $client = null, $baseUrl = null)
+    public function __construct(Client $client, $baseUrl = null)
     {
         $this->client = $client;
         $this->client->followRedirects(true);


### PR DESCRIPTION
Passing null for the client is invalid. It would trigger fatal errors when using the driver.
