### PR TITLE
Deprecated the URL alteration in visit()

### DIFF
--- a/src/Behat/Mink/Driver/BrowserKitDriver.php
+++ b/src/Behat/Mink/Driver/BrowserKitDriver.php
@@ -45,7 +45,7 @@ class BrowserKitDriver extends CoreDriver
     private $forms = array();
     private $serverParameters = array();
     private $started = false;
-    private $removeScriptFromUrl = true;
+    private $removeScriptFromUrl = false;
     private $removeHostFromUrl = false;
 
     /**
@@ -61,7 +61,6 @@ class BrowserKitDriver extends CoreDriver
 
         if ($baseUrl !== null && $client instanceof HttpKernelClient) {
             $client->setServerParameter('SCRIPT_FILENAME', parse_url($baseUrl, PHP_URL_PATH));
-            $this->removeScriptFromUrl = false;
         }
     }
 

--- a/tests/Behat/Mink/Driver/BrowserKitDriverTest.php
+++ b/tests/Behat/Mink/Driver/BrowserKitDriverTest.php
@@ -15,7 +15,6 @@ class BrowserKitDriverTest extends GeneralDriverTest
     {
         $client = new Client(require(__DIR__.'/../../../app.php'));
         $driver = new BrowserKitDriver($client);
-        $driver->setRemoveScriptFromUrl(false);
 
         return $driver;
     }


### PR DESCRIPTION
This was introduced to strip the base url from the url when using the HttpKernel client in early versions of the driver. However, this was only half-working as it was impacting the current url later. A proper way to support the base url has been introduced for the HttpKernel client, so the old one can be deprecated.
