### PR TITLE
Checkbox fields should return the value when checked

### DIFF
--- a/src/Behat/Mink/Driver/BrowserKitDriver.php
+++ b/src/Behat/Mink/Driver/BrowserKitDriver.php
@@ -431,13 +431,7 @@ class BrowserKitDriver extends CoreDriver
             return $this->getAttribute($xpath, 'value');
         }
 
-        $value = $field->getValue();
-
-        if ($field instanceof ChoiceFormField && 'checkbox' === $field->getType()) {
-            $value = null !== $value;
-        }
-
-        return $value;
+        return $field->getValue();
     }
 
     /**


### PR DESCRIPTION
When checked the checkbox should return the value of the value attribute instead of boolean of wether it is checked or not. Refer to https://github.com/Behat/Mink/issues/587
