### PR TITLE
Improve the Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+sudo: false
+
 php: [5.3, 5.4, 5.5, 5.6, hhvm]
 
 matrix:
@@ -9,12 +11,17 @@ matrix:
     - php: 5.5
       env: SYMFONY_VERSION='2.5.*@dev'
 
-before_script:
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+before_install:
   - sh -c 'if [ "$SYMFONY_VERSION" != "" ]; then composer require -n --no-update symfony/symfony=$SYMFONY_VERSION; fi;'
-  - composer install -n --prefer-source
+
+install:
+  - composer install -n
 
 script: phpunit -v --coverage-clover=coverage.clover
 
 after_script:
-  - wget https://scrutinizer-ci.com/ocular.phar
-  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+  - wget https://scrutinizer-ci.com/ocular.phar && php ocular.phar code-coverage:upload --format=php-clover coverage.clover


### PR DESCRIPTION
- switch to the faster Docker-based infrastructure given that we don't need to use sudo in the build
- cache the composer cache between builds, which is possible on the new infrasture, to be able to reuse previous downloads.
- switch to use archive downloads for stable dependencies. Composer is now able to fallback to source install when the github API rate limit is reached, and the usage of the cache should avoid hitting the github API for many downloads.

this is exactly the same than https://github.com/minkphp/Mink/pull/632