### PR TITLE
Use saveHTML to get correct HTML code back

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
 
     "require": {
-        "php":                  ">=5.3.1",
+        "php":                  ">=5.3.6",
         "behat/mink":           "~1.7@dev",
         "symfony/browser-kit":  "~2.3",
         "symfony/dom-crawler":  "~2.3"

--- a/src/BrowserKitDriver.php
+++ b/src/BrowserKitDriver.php
@@ -367,7 +367,7 @@ class BrowserKitDriver extends CoreDriver
     {
         $node = $this->getCrawlerNode($this->getFilteredCrawler($xpath));
 
-        return $node->ownerDocument->saveXML($node);
+        return $node->ownerDocument->saveHTML($node);
     }
 
     /**


### PR DESCRIPTION
Assume this HTML code:
````html
<div id="elem">
    <script src="foo.js"></script>

    <h2>Hello!</h2>
</div>
````

Using `$elem->getXml()` resulted in:
````xml
<script src="foo.js"/>

<h2>Hello!</h2>
````

Which is incorrect HTML and is interpreted by browsers as if `<script>` was never closed ([script tags are really weird in HTML](https://mathiasbynens.be/notes/etago)).

Using `$elem->getHtml()` results in correct HTML using `</script>`.