### PR TITLE
Removed the BC layers for Symfony 2.2 and older

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     "require": {
         "php":                  ">=5.3.1",
         "behat/mink":           "~1.7@dev",
-        "symfony/browser-kit":  "~2.0",
-        "symfony/dom-crawler":  "~2.0"
+        "symfony/browser-kit":  "~2.3",
+        "symfony/dom-crawler":  "~2.3"
     },
 
     "require-dev": {

--- a/src/BrowserKitDriver.php
+++ b/src/BrowserKitDriver.php
@@ -14,7 +14,6 @@ use Behat\Mink\Exception\DriverException;
 use Behat\Mink\Exception\UnsupportedDriverActionException;
 use Symfony\Component\BrowserKit\Client;
 use Symfony\Component\BrowserKit\Cookie;
-use Symfony\Component\BrowserKit\Request;
 use Symfony\Component\BrowserKit\Response;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\DomCrawler\Field\ChoiceFormField;
@@ -23,8 +22,6 @@ use Symfony\Component\DomCrawler\Field\FormField;
 use Symfony\Component\DomCrawler\Field\InputFormField;
 use Symfony\Component\DomCrawler\Field\TextareaFormField;
 use Symfony\Component\DomCrawler\Form;
-use Symfony\Component\HttpFoundation\Request as HttpFoundationRequest;
-use Symfony\Component\HttpFoundation\Response as HttpFoundationResponse;
 use Symfony\Component\HttpKernel\Client as HttpKernelClient;
 
 /**
@@ -153,19 +150,7 @@ class BrowserKitDriver extends CoreDriver
      */
     public function getCurrentUrl()
     {
-        if (method_exists($this->client, 'getInternalRequest')) {
-            $request = $this->client->getInternalRequest();
-        } else {
-            // BC layer for BrowserKit 2.2.x and older
-            $request = $this->client->getRequest();
-
-            if (null !== $request && !$request instanceof Request && !$request instanceof HttpFoundationRequest) {
-                throw new DriverException(sprintf(
-                    'The BrowserKit client returned an unsupported request implementation: %s. Please upgrade your BrowserKit package to 2.3 or newer.',
-                    get_class($request)
-                ));
-            }
-        }
+        $request = $this->client->getInternalRequest();
 
         if ($request === null) {
             throw new DriverException('Unable to access the request before visiting a page');
@@ -553,16 +538,6 @@ class BrowserKitDriver extends CoreDriver
      */
     protected function getResponse()
     {
-        if (!method_exists($this->client, 'getInternalResponse')) {
-            $implementationResponse = $this->client->getResponse();
-
-            if (null === $implementationResponse) {
-                throw new DriverException('Unable to access the response before visiting a page');
-            }
-
-            return $this->convertImplementationResponse($implementationResponse);
-        }
-
         $response = $this->client->getInternalResponse();
 
         if (null === $response) {
@@ -570,64 +545,6 @@ class BrowserKitDriver extends CoreDriver
         }
 
         return $response;
-    }
-
-    /**
-     * Gets the BrowserKit Response for legacy BrowserKit versions.
-     *
-     * Before 2.3.0, there was no Client::getInternalResponse method, and the
-     * return value of Client::getResponse can be anything when the implementation
-     * uses Client::filterResponse because of a bad choice done in BrowserKit and
-     * kept for BC reasons (the Client::getInternalResponse method has been added
-     * to solve it).
-     *
-     * This implementation supports client which don't rely Client::filterResponse
-     * and clients which use an HttpFoundation Response (like the HttpKernel client).
-     *
-     * @param object $response the response specific to the BrowserKit implementation
-     *
-     * @return Response
-     *
-     * @throws DriverException If the response cannot be converted to a BrowserKit response
-     */
-    private function convertImplementationResponse($response)
-    {
-        if ($response instanceof Response) {
-            return $response;
-        }
-
-        // due to a bug, the HttpKernel client implementation returns the HttpFoundation response
-        // The conversion logic is copied from Symfony\Component\HttpKernel\Client::filterResponse
-        if ($response instanceof HttpFoundationResponse) {
-            $headers = $response->headers->all();
-            if ($response->headers->getCookies()) {
-                $cookies = array();
-                foreach ($response->headers->getCookies() as $cookie) {
-                    $cookies[] = new Cookie(
-                        $cookie->getName(),
-                        $cookie->getValue(),
-                        $cookie->getExpiresTime(),
-                        $cookie->getPath(),
-                        $cookie->getDomain(),
-                        $cookie->isSecure(),
-                        $cookie->isHttpOnly()
-                    );
-                }
-                $headers['Set-Cookie'] = $cookies;
-            }
-
-            // this is needed to support StreamedResponse
-            ob_start();
-            $response->sendContent();
-            $content = ob_get_clean();
-
-            return new Response($content, $response->getStatusCode(), $headers);
-        }
-
-        throw new DriverException(sprintf(
-            'The BrowserKit client returned an unsupported response implementation: %s. Please upgrade your BrowserKit package to 2.3 or newer.',
-            get_class($response)
-        ));
     }
 
     /**


### PR DESCRIPTION
Symfony 2.2 is EOLed since 1 year: http://symfony.com/roadmap?version=2.2#checker

I think we can be fine with dropping the support for it in the next minor version of the driver (1.3.0) rather than bumping the major version.

People using Mink inside Behat already lost the compatibility with these unmaintained Symfony versions anyway btw, and I don't think anyone should be using unmaintained versions, so it is acceptable IMO (people who don't update their Symfony dependency will be fine with not updating their Mink driver anyway)