### PR TITLE
Allow installation of this driver with symfony3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,19 @@ matrix:
       env: SYMFONY_VERSION='2.3.*'
     - php: 5.5
       env: SYMFONY_VERSION='2.5.*@dev'
+    - php: 5.6
+      env: SYMFONY_VERSION='2.8.*@dev'
+    - php: 5.6
+      env: DEPENDENCIES='dev' SYMFONY_VERSION='3.0.*@dev'
+  allow_failures:
+    - env: DEPENDENCIES='dev' SYMFONY_VERSION='3.0.*@dev'
 
 cache:
   directories:
     - $HOME/.composer/cache/files
 
 before_install:
+  - if [ "$DEPENDENCIES" = "dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
   - sh -c 'if [ "$SYMFONY_VERSION" != "" ]; then composer require -n --no-update symfony/symfony=$SYMFONY_VERSION; fi;'
 
 install:

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
     "require": {
         "php":                  ">=5.3.6",
         "behat/mink":           "~1.7@dev",
-        "symfony/browser-kit":  "~2.3",
-        "symfony/dom-crawler":  "~2.3"
+        "symfony/browser-kit":  "~2.3|~3.0",
+        "symfony/dom-crawler":  "~2.3|~3.0"
     },
 
     "require-dev": {
-        "symfony/phpunit-bridge": "~2.7",
+        "symfony/phpunit-bridge": "~2.7|~3.0",
         "silex/silex": "~1.2"
     },
 

--- a/src/BrowserKitDriver.php
+++ b/src/BrowserKitDriver.php
@@ -807,7 +807,14 @@ class BrowserKitDriver extends CoreDriver
      */
     private function getCrawlerNode(Crawler $crawler)
     {
-        $node = $crawler->getNode(0);
+        $node = null;
+
+        if ($crawler instanceof \IteratorAggregate) {
+            $node = $crawler->getNode(0);
+        } else {
+            $crawler->rewind();
+            $node = $crawler->current();
+        }
 
         if (null !== $node) {
             return $node;

--- a/src/BrowserKitDriver.php
+++ b/src/BrowserKitDriver.php
@@ -809,11 +809,12 @@ class BrowserKitDriver extends CoreDriver
     {
         $node = null;
 
-        if ($crawler instanceof \IteratorAggregate) {
-            $node = $crawler->getNode(0);
-        } else {
+        if ($crawler instanceof \Iterator) {
+            // for symfony 2.3 compatibility as getNode is not public before symfony 2.4
             $crawler->rewind();
             $node = $crawler->current();
+        } else {
+            $node = $crawler->getNode(0);
         }
 
         if (null !== $node) {

--- a/src/BrowserKitDriver.php
+++ b/src/BrowserKitDriver.php
@@ -807,8 +807,7 @@ class BrowserKitDriver extends CoreDriver
      */
     private function getCrawlerNode(Crawler $crawler)
     {
-        $crawler->rewind();
-        $node = $crawler->current();
+        $node = $crawler->getNode(0);
 
         if (null !== $node) {
             return $node;


### PR DESCRIPTION
my pull request on mink (https://github.com/minkphp/Mink/pull/681)  should be merge before this one.

I don't know how to keep compatibility with Symfony 2.3 (the getNode method was protected), but in Symfony 3.0 the Crawler don't extends the SplObjectStorage, so we can't retrieve the first DomElement with the same method