### PR TITLE
Remove windows line breaks as well

### DIFF
--- a/src/BrowserKitDriver.php
+++ b/src/BrowserKitDriver.php
@@ -346,6 +346,7 @@ class BrowserKitDriver extends CoreDriver
     {
         $text = $this->getFilteredCrawler($xpath)->text();
         $text = str_replace("\n", ' ', $text);
+        $text = str_replace("\r", '', $text);
         $text = preg_replace('/ {2,}/', ' ', $text);
 
         return trim($text);


### PR DESCRIPTION
Since windows uses `\r\n` for line breaks, behat tests fail with a string compare.