### PR TITLE
Support for Symfony 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ matrix:
     # Test against dev versions of dependencies
     - php: 5.6
       env: DEPENDENCIES='dev'
+    - php: 7.0
+      env: DEPENDENCIES='dev'
+    - php: 7.1
+      env: DEPENDENCIES='dev'
 
 cache:
   directories:

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     "require": {
         "php":                  ">=5.3.6",
         "behat/mink":           "^1.7.1@dev",
-        "symfony/browser-kit":  "~2.3|~3.0",
-        "symfony/dom-crawler":  "~2.3|~3.0"
+        "symfony/browser-kit":  "~2.3|~3.0|~4.0",
+        "symfony/dom-crawler":  "~2.3|~3.0|~4.0"
     },
 
     "require-dev": {


### PR DESCRIPTION
Just minor update of versions and Travis tests for 7.0 and 7.1. Since Symfony is in beta I used the DEPENDENCIES='dev' #SymfonyConHackday2017