### PR TITLE
Handle Symfony 5+ behaviour for Client::getInternalRequest/getInternalResponse

### DIFF
--- a/src/BrowserKitDriver.php
+++ b/src/BrowserKitDriver.php
@@ -14,6 +14,7 @@ use Behat\Mink\Exception\DriverException;
 use Behat\Mink\Exception\UnsupportedDriverActionException;
 use Symfony\Component\BrowserKit\Client;
 use Symfony\Component\BrowserKit\Cookie;
+use Symfony\Component\BrowserKit\Exception\BadMethodCallException;
 use Symfony\Component\BrowserKit\Response;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\DomCrawler\Field\ChoiceFormField;
@@ -150,7 +151,13 @@ class BrowserKitDriver extends CoreDriver
      */
     public function getCurrentUrl()
     {
-        $request = $this->client->getInternalRequest();
+        // This should be encapsulated in `getRequest` method if any other method needs the request
+        try {
+            $request = $this->client->getInternalRequest();
+        } catch (BadMethodCallException $e) {
+            // Handling Symfony 5+ behaviour
+            $request = null;
+        }
 
         if ($request === null) {
             throw new DriverException('Unable to access the request before visiting a page');
@@ -538,7 +545,12 @@ class BrowserKitDriver extends CoreDriver
      */
     protected function getResponse()
     {
-        $response = $this->client->getInternalResponse();
+        try {
+            $response = $this->client->getInternalResponse();
+        } catch (BadMethodCallException $e) {
+            // Handling Symfony 5+ behaviour
+            $response = null;
+        }
 
         if (null === $response) {
             throw new DriverException('Unable to access the response before visiting a page');

--- a/tests/Custom/ErrorHandlingTest.php
+++ b/tests/Custom/ErrorHandlingTest.php
@@ -27,6 +27,10 @@ class ErrorHandlingTest extends TestCase
     /**
      * @expectedException \Behat\Mink\Exception\DriverException
      * @expectedExceptionMessage Unable to access the response before visiting a page
+     *
+     * Looks like we have to mark these tests as "legacy", otherwise we get deprecation errors.
+     * Although the deprecations are handled, there's no way to avoid the deprecation message here.
+     * @group legacy
      */
     public function testGetResponseHeaderWithoutVisit()
     {
@@ -36,6 +40,10 @@ class ErrorHandlingTest extends TestCase
     /**
      * @expectedException \Behat\Mink\Exception\DriverException
      * @expectedExceptionMessage Unable to access the response content before visiting a page
+     *
+     * Looks like we have to mark these tests as "legacy", otherwise we get deprecation errors.
+     * Although the deprecations are handled, there's no way to avoid the deprecation message here.
+     * @group legacy
      */
     public function testFindWithoutVisit()
     {
@@ -45,6 +53,10 @@ class ErrorHandlingTest extends TestCase
     /**
      * @expectedException \Behat\Mink\Exception\DriverException
      * @expectedExceptionMessage Unable to access the request before visiting a page
+     *
+     * Looks like we have to mark these tests as "legacy", otherwise we get deprecation errors.
+     * Although the deprecations are handled, there's no way to avoid the deprecation message here.
+     * @group legacy
      */
     public function testGetCurrentUrlWithoutVisit()
     {


### PR DESCRIPTION
Symfony deprecated accessing `Client::getInternalRequest()` and `Client::getInternalResponse()` without first making `request()`. In Symfony 5+ it will throw exception so we're both handling the exception and deprecation messages in this PR.
Unfortunately, there's no way to avoid deprecation messages without tracking request on our end so I just marked a few tests as "legacy" that were testing this specific behaviour of accessing request/response without response first.