### PR TITLE
Remove HHVM support and add PHP 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,19 @@ language: php
 
 sudo: false
 
-php: [5.4, 5.5, 5.6, 7.0, 7.1, hhvm]
+php: [5.4, 5.5, 5.6, 7.0, 7.1, 7.2]
 
 matrix:
   include:
     - php: 5.3
       dist: precise
     # Test against LTS versions
-    - php: 7.1
+    - php: 7.2
       env: SYMFONY_VERSION='^2'
-    - php: 7.1
+    - php: 7.2
       env: SYMFONY_VERSION='^3'
     # Test against dev versions of dependencies
-    - php: 7.1
+    - php: 7.2
       env: DEPENDENCIES='dev'
 
 cache:


### PR DESCRIPTION
Removed HHVM since it's longer gonna be PHP compatible.
Added PHP 7.2 as the latest stable PHP version.