### PR TITLE
Update for Symfony 4 HttpFoundation\Cookie::__construct() deprecations.

### DIFF
--- a/src/BrowserKitDriver.php
+++ b/src/BrowserKitDriver.php
@@ -244,7 +244,7 @@ class BrowserKitDriver extends CoreDriver
         }
 
         $jar = $this->client->getCookieJar();
-        $jar->set(new Cookie($name, $value));
+        $jar->set(new Cookie($name, $value, 0, '/', null, false, true, false, null));
     }
 
     /**


### PR DESCRIPTION
Symfony has introduced a deprecation for a couple of default values for HttpFoundation\Cookie::__construct() as a bridge to changing them for Symfony 5. The simplest change is to just call all the constructor arguments explicitly for now, although it would also be possible to switch to ::create().

See https://github.com/symfony/http-foundation/blob/master/Cookie.php#L91 for the deprecation.