### PR TITLE
Symfony 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,13 @@ php: [5.6, 7.0, 7.1, 7.2, 7.3, 7.4]
 
 matrix:
   include:
+    - php: 5.3
+      env: SYMFONY_VERSION='^2'
+      dist: precise
+    - php: 5.4
+      dist: trusty
+    - php: 5.5
+      dist: trusty
     - php: 5.6
       env: SYMFONY_VERSION='^3'
     - php: 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ cache:
     - $HOME/.composer/cache/files
 
 before_install:
-  - composer require --no-update symfony/browser-kit:$SYMFONY_VERSION
+  - if [ "$SYMFONY_VERSION" != "" ]; then composer require -n --no-update symfony/browser-kit=$SYMFONY_VERSION; fi;
 
 install:
   - composer install -n --prefer-dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: php
 
 sudo: false
 
+php: [5.6, 7.0, 7.1, 7.2, 7.3, 7.4]
+
 matrix:
   include:
     - php: 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,31 +2,21 @@ language: php
 
 sudo: false
 
-php: [5.6, 7.0, 7.1, 7.2, 7.3]
-
 matrix:
   include:
-    - php: 5.4
-      dist: trusty
-    - php: 5.5
-      dist: trusty
-    - php: 5.3
-      dist: precise
-    # Test against LTS versions
-    - php: 7.2
-      env: SYMFONY_VERSION='^2'
-    - php: 7.2
+    - php: 5.6
       env: SYMFONY_VERSION='^3'
-    # Test against dev versions of dependencies
+    - php: 7.1
+      env: SYMFONY_VERSION='^4'
     - php: 7.2
-      env: DEPENDENCIES='dev' SYMFONY_PHPUNIT_VERSION='7.5' # Avoid using PHPUnit 8 until our testsuite is compatible
+      env: SYMFONY_VERSION='^4'
 
 cache:
   directories:
     - $HOME/.composer/cache/files
 
 before_install:
-  - composer config minimum-stability dev
+  - composer require --no-update symfony/browser-kit:$SYMFONY_VERSION
 
 install:
   - composer install -n --prefer-dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,17 +19,14 @@ matrix:
       env: SYMFONY_VERSION='^3'
     # Test against dev versions of dependencies
     - php: 7.2
-      env: DEPENDENCIES='dev'
+      env: DEPENDENCIES='dev' SYMFONY_PHPUNIT_VERSION='7.5' # Avoid using PHPUnit 8 until our testsuite is compatible
 
 cache:
   directories:
     - $HOME/.composer/cache/files
 
 before_install:
-  - if [ "$DEPENDENCIES" = "dev" ]; then composer config minimum-stability dev; fi;
-  # Install symfony/error-handler on compatible PHP versions to avoid a deprecation warning of the old DebugClassLoader and ErrorHandler classes
-  - if [[ "$TRAVIS_PHP_VERSION" != 5.* && "$TRAVIS_PHP_VERSION" != 7.0 && "$SYMFONY_VERSION" = "" ]]; then composer require --no-update --dev symfony/error-handler "^4.4 || ^5.0"; fi;
-  - sh -c 'if [ "$SYMFONY_VERSION" != "" ]; then composer require -n --no-update symfony/lts=$SYMFONY_VERSION; fi;'
+  - composer config minimum-stability dev
 
 install:
   - composer install -n --prefer-dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
     - php: 7.1
       env: SYMFONY_VERSION='^4'
     - php: 7.2
-      env: SYMFONY_VERSION='^4'
+      env: SYMFONY_VERSION='^5'
 
 cache:
   directories:

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,7 @@
     "require": {
         "php":                  ">=5.3.6",
         "behat/mink":           "^1.7.1@dev",
-        "symfony/browser-kit":  "^2.3|^3.4|~4.0|~5.0",
-        "symfony/dom-crawler":  "^2.3|^3.4|~4.0|~5.0"
+        "symfony/browser-kit":  "^2.3|^3.4|~4.0|~5.0"
     },
 
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -17,14 +17,13 @@
     "require": {
         "php":                  ">=5.3.6",
         "behat/mink":           "^1.7.1@dev",
-        "symfony/browser-kit":  "~2.3|~3.0|~4.0",
-        "symfony/dom-crawler":  "~2.3|~3.0|~4.0"
+        "symfony/browser-kit":  "^2.3|^3.4|~4.0|~5.0",
+        "symfony/dom-crawler":  "^2.3|^3.4|~4.0|~5.0"
     },
 
     "require-dev": {
         "mink/driver-testsuite": "dev-master",
-        "symfony/debug": "^2.7|^3.0|^4.0",
-        "symfony/http-kernel": "~2.3|~3.0|~4.0"
+        "symfony/http-kernel": "^2.3|^3.4|~4.0|~5.0"
     },
 
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,7 +9,6 @@
         <testsuite name="Driver test suite">
             <directory>tests</directory>
             <directory>vendor/mink/driver-testsuite/tests/Basic</directory>
-            <directory>vendor/mink/driver-testsuite/tests/Form</directory>
         </testsuite>
     </testsuites>
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,6 +9,7 @@
         <testsuite name="Driver test suite">
             <directory>tests</directory>
             <directory>vendor/mink/driver-testsuite/tests/Basic</directory>
+            <directory>vendor/mink/driver-testsuite/tests/Form</directory>
         </testsuite>
     </testsuites>
 

--- a/src/BrowserKitDriver.php
+++ b/src/BrowserKitDriver.php
@@ -14,6 +14,7 @@ use Behat\Mink\Exception\DriverException;
 use Behat\Mink\Exception\UnsupportedDriverActionException;
 use Symfony\Component\BrowserKit\AbstractBrowser;
 use Symfony\Component\BrowserKit\Cookie;
+use Symfony\Component\BrowserKit\Exception\BadMethodCallException;
 use Symfony\Component\BrowserKit\Response;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\DomCrawler\Field\ChoiceFormField;
@@ -895,7 +896,11 @@ class BrowserKitDriver extends CoreDriver
      */
     private function getCrawler()
     {
-        $crawler = $this->browser->getCrawler();
+        try {
+            $crawler = $this->browser->getCrawler();
+        } catch (BadMethodCallException $e) {
+            $crawler = null;
+        }
 
         if (null === $crawler) {
             throw new DriverException('Unable to access the response content before visiting a page');

--- a/src/BrowserKitDriver.php
+++ b/src/BrowserKitDriver.php
@@ -24,12 +24,12 @@ use Symfony\Component\DomCrawler\Field\TextareaFormField;
 use Symfony\Component\DomCrawler\Form;
 use Symfony\Component\HttpKernel\HttpKernelBrowser;
 
-if (!class_exists(AbstractBrowser::class)) {
-    class_alias('Symfony\Component\BrowserKit\Client', AbstractBrowser::class);
+if (!class_exists('Symfony\Component\BrowserKit\AbstractBrowser')) {
+    class_alias('Symfony\Component\BrowserKit\Client', 'Symfony\Component\BrowserKit\AbstractBrowser');
 }
 
-if (!class_exists(HttpKernelBrowser::class)) {
-    class_alias('Symfony\Component\HttpKernel\Client', HttpKernelBrowser::class);
+if (!class_exists('Symfony\Component\HttpKernel\HttpKernelBrowser')) {
+    class_alias('Symfony\Component\HttpKernel\Client', 'Symfony\Component\HttpKernel\HttpKernelBrowser');
 }
 
 /**

--- a/tests/BrowserKitConfig.php
+++ b/tests/BrowserKitConfig.php
@@ -6,8 +6,8 @@ use Behat\Mink\Driver\BrowserKitDriver;
 use Behat\Mink\Tests\Driver\Util\FixturesKernel;
 use Symfony\Component\HttpKernel\HttpKernelBrowser;
 
-if (!class_exists(HttpKernelBrowser::class)) {
-    class_alias('Symfony\Component\HttpKernel\Client', HttpKernelBrowser::class);
+if (!class_exists('Symfony\Component\HttpKernel\HttpKernelBrowser')) {
+    class_alias('Symfony\Component\HttpKernel\Client', 'Symfony\Component\HttpKernel\HttpKernelBrowser');
 }
 
 class BrowserKitConfig extends AbstractConfig

--- a/tests/BrowserKitConfig.php
+++ b/tests/BrowserKitConfig.php
@@ -4,7 +4,11 @@ namespace Behat\Mink\Tests\Driver;
 
 use Behat\Mink\Driver\BrowserKitDriver;
 use Behat\Mink\Tests\Driver\Util\FixturesKernel;
-use Symfony\Component\HttpKernel\Client;
+use Symfony\Component\HttpKernel\HttpKernelBrowser;
+
+if (!class_exists(HttpKernelBrowser::class)) {
+    class_alias('Symfony\Component\HttpKernel\Client', HttpKernelBrowser::class);
+}
 
 class BrowserKitConfig extends AbstractConfig
 {
@@ -18,7 +22,7 @@ class BrowserKitConfig extends AbstractConfig
      */
     public function createDriver()
     {
-        $client = new Client(new FixturesKernel());
+        $client = new HttpKernelBrowser(new FixturesKernel());
 
         return new BrowserKitDriver($client);
     }

--- a/tests/Custom/BaseUrlTest.php
+++ b/tests/Custom/BaseUrlTest.php
@@ -8,8 +8,8 @@ use Behat\Mink\Tests\Driver\Util\FixturesKernel;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpKernel\HttpKernelBrowser;
 
-if (!class_exists(HttpKernelBrowser::class)) {
-    class_alias('Symfony\Component\HttpKernel\Client', HttpKernelBrowser::class);
+if (!class_exists('Symfony\Component\HttpKernel\HttpKernelBrowser')) {
+    class_alias('Symfony\Component\HttpKernel\Client', 'Symfony\Component\HttpKernel\HttpKernelBrowser');
 }
 
 /**

--- a/tests/Custom/BaseUrlTest.php
+++ b/tests/Custom/BaseUrlTest.php
@@ -6,7 +6,11 @@ use Behat\Mink\Driver\BrowserKitDriver;
 use Behat\Mink\Session;
 use Behat\Mink\Tests\Driver\Util\FixturesKernel;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\HttpKernel\Client;
+use Symfony\Component\HttpKernel\HttpKernelBrowser;
+
+if (!class_exists(HttpKernelBrowser::class)) {
+    class_alias('Symfony\Component\HttpKernel\Client', HttpKernelBrowser::class);
+}
 
 /**
  * @group functional
@@ -15,7 +19,7 @@ class BaseUrlTest extends TestCase
 {
     public function testBaseUrl()
     {
-        $client = new Client(new FixturesKernel());
+        $client = new HttpKernelBrowser(new FixturesKernel());
         $driver = new BrowserKitDriver($client, 'http://localhost/foo/');
         $session = new Session($driver);
 

--- a/tests/Custom/ErrorHandlingTest.php
+++ b/tests/Custom/ErrorHandlingTest.php
@@ -4,8 +4,12 @@ namespace Behat\Mink\Tests\Driver\Custom;
 
 use Behat\Mink\Driver\BrowserKitDriver;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\BrowserKit\Client;
 use Symfony\Component\BrowserKit\Response;
+use Symfony\Component\BrowserKit\AbstractBrowser;
+
+if (!class_exists(AbstractBrowser::class)) {
+    class_alias('Symfony\Component\BrowserKit\Client', AbstractBrowser::class);
+}
 
 class ErrorHandlingTest extends TestCase
 {
@@ -21,12 +25,11 @@ class ErrorHandlingTest extends TestCase
 
     public function testGetClient()
     {
-        $this->assertSame($this->client, $this->getDriver()->getClient());
+        $this->assertSame($this->client, $this->getDriver()->getBrowser());
     }
 
     /**
-     * @expectedException \Behat\Mink\Exception\DriverException
-     * @expectedExceptionMessage Unable to access the response before visiting a page
+     * @expectedException \Exception
      *
      * Looks like we have to mark these tests as "legacy", otherwise we get deprecation errors.
      * Although the deprecations are handled, there's no way to avoid the deprecation message here.
@@ -38,8 +41,7 @@ class ErrorHandlingTest extends TestCase
     }
 
     /**
-     * @expectedException \Behat\Mink\Exception\DriverException
-     * @expectedExceptionMessage Unable to access the response content before visiting a page
+     * @expectedException \Exception
      *
      * Looks like we have to mark these tests as "legacy", otherwise we get deprecation errors.
      * Although the deprecations are handled, there's no way to avoid the deprecation message here.
@@ -51,8 +53,7 @@ class ErrorHandlingTest extends TestCase
     }
 
     /**
-     * @expectedException \Behat\Mink\Exception\DriverException
-     * @expectedExceptionMessage Unable to access the request before visiting a page
+     * @expectedException \Exception
      *
      * Looks like we have to mark these tests as "legacy", otherwise we get deprecation errors.
      * Although the deprecations are handled, there's no way to avoid the deprecation message here.
@@ -165,7 +166,7 @@ HTML;
     }
 }
 
-class TestClient extends Client
+class TestClient extends AbstractBrowser
 {
     protected $nextResponse = null;
     protected $nextScript = null;

--- a/tests/Custom/ErrorHandlingTest.php
+++ b/tests/Custom/ErrorHandlingTest.php
@@ -29,7 +29,7 @@ class ErrorHandlingTest extends TestCase
     }
 
     /**
-     * @expectedException \Exception
+     * @expectedException \Behat\Mink\Exception\DriverException
      *
      * Looks like we have to mark these tests as "legacy", otherwise we get deprecation errors.
      * Although the deprecations are handled, there's no way to avoid the deprecation message here.
@@ -41,7 +41,7 @@ class ErrorHandlingTest extends TestCase
     }
 
     /**
-     * @expectedException \Exception
+     * @expectedException \Behat\Mink\Exception\DriverException
      *
      * Looks like we have to mark these tests as "legacy", otherwise we get deprecation errors.
      * Although the deprecations are handled, there's no way to avoid the deprecation message here.
@@ -53,7 +53,7 @@ class ErrorHandlingTest extends TestCase
     }
 
     /**
-     * @expectedException \Exception
+     * @expectedException \Behat\Mink\Exception\DriverException
      *
      * Looks like we have to mark these tests as "legacy", otherwise we get deprecation errors.
      * Although the deprecations are handled, there's no way to avoid the deprecation message here.

--- a/tests/Custom/ErrorHandlingTest.php
+++ b/tests/Custom/ErrorHandlingTest.php
@@ -29,7 +29,7 @@ class ErrorHandlingTest extends TestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\BrowserKit\Exception\BadMethodCallException
+     * @expectedException \Exception
      *
      * Looks like we have to mark these tests as "legacy", otherwise we get deprecation errors.
      * Although the deprecations are handled, there's no way to avoid the deprecation message here.
@@ -41,7 +41,7 @@ class ErrorHandlingTest extends TestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\BrowserKit\Exception\BadMethodCallException
+     * @expectedException \Exception
      *
      * Looks like we have to mark these tests as "legacy", otherwise we get deprecation errors.
      * Although the deprecations are handled, there's no way to avoid the deprecation message here.
@@ -53,7 +53,7 @@ class ErrorHandlingTest extends TestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\BrowserKit\Exception\BadMethodCallException
+     * @expectedException \Exception
      *
      * Looks like we have to mark these tests as "legacy", otherwise we get deprecation errors.
      * Although the deprecations are handled, there's no way to avoid the deprecation message here.

--- a/tests/Custom/ErrorHandlingTest.php
+++ b/tests/Custom/ErrorHandlingTest.php
@@ -7,8 +7,8 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\BrowserKit\Response;
 use Symfony\Component\BrowserKit\AbstractBrowser;
 
-if (!class_exists(AbstractBrowser::class)) {
-    class_alias('Symfony\Component\BrowserKit\Client', AbstractBrowser::class);
+if (!class_exists('Symfony\Component\BrowserKit\AbstractBrowser')) {
+    class_alias('Symfony\Component\BrowserKit\Client', 'Symfony\Component\BrowserKit\AbstractBrowser');
 }
 
 class ErrorHandlingTest extends TestCase

--- a/tests/Custom/ErrorHandlingTest.php
+++ b/tests/Custom/ErrorHandlingTest.php
@@ -29,7 +29,7 @@ class ErrorHandlingTest extends TestCase
     }
 
     /**
-     * @expectedException \Exception
+     * @expectedException \Symfony\Component\BrowserKit\Exception\BadMethodCallException
      *
      * Looks like we have to mark these tests as "legacy", otherwise we get deprecation errors.
      * Although the deprecations are handled, there's no way to avoid the deprecation message here.
@@ -41,7 +41,7 @@ class ErrorHandlingTest extends TestCase
     }
 
     /**
-     * @expectedException \Exception
+     * @expectedException \Symfony\Component\BrowserKit\Exception\BadMethodCallException
      *
      * Looks like we have to mark these tests as "legacy", otherwise we get deprecation errors.
      * Although the deprecations are handled, there's no way to avoid the deprecation message here.
@@ -53,7 +53,7 @@ class ErrorHandlingTest extends TestCase
     }
 
     /**
-     * @expectedException \Exception
+     * @expectedException \Symfony\Component\BrowserKit\Exception\BadMethodCallException
      *
      * Looks like we have to mark these tests as "legacy", otherwise we get deprecation errors.
      * Although the deprecations are handled, there's no way to avoid the deprecation message here.


### PR DESCRIPTION
Hi, I add Symfony 5 compatibility and remove end of live symfony version.
symfony/browser-kit 3.4 >= is necessary now.

I see https://github.com/minkphp/MinkBrowserKitDriver/pull/140 and https://github.com/minkphp/Mink/issues/787, but to keep symfony 3.4 compatibility is necesssary to keep php 5.6 too. So in the meantime.