### PR TITLE
Improve compatibility with crawler in HTML5 mode

### DIFF
--- a/src/BrowserKitDriver.php
+++ b/src/BrowserKitDriver.php
@@ -370,8 +370,7 @@ class BrowserKitDriver extends CoreDriver
      */
     public function getHtml($xpath)
     {
-        // cut the tag itself (making innerHTML out of outerHTML)
-        return preg_replace('/^\<[^\>]+\>|\<[^\>]+\>$/', '', $this->getOuterHtml($xpath));
+        return $this->getFilteredCrawler($xpath)->html();
     }
 
     /**
@@ -379,7 +378,13 @@ class BrowserKitDriver extends CoreDriver
      */
     public function getOuterHtml($xpath)
     {
-        $node = $this->getCrawlerNode($this->getFilteredCrawler($xpath));
+        $crawler = $this->getFilteredCrawler($xpath);
+
+        if (method_exists($crawler, 'outerHtml')) {
+            return $crawler->outerHtml();
+        }
+
+        $node = $this->getCrawlerNode($crawler);
 
         return $node->ownerDocument->saveHTML($node);
     }


### PR DESCRIPTION
As of 4.3, symfony/dom-crawler will automatically pick masterminds/html5 as the parser when it is installed and the HTML uses the HTML5 doctype. This provides better support for HTML5, but requires using the saveHTML() method of the library rather than of the DOMDocument to avoid weird edge cases.
Given that the Crawler methods dealing with HTML are already taking care of that, they are now used by the driver rather than using the DOMDocument API. The implementation of outerHTML still ships a fallback as the Crawler has the method only in 4.4+.