### PR TITLE
Fix the detection of HTML5 support in the testsuite

### DIFF
--- a/tests/BrowserKitConfig.php
+++ b/tests/BrowserKitConfig.php
@@ -45,6 +45,8 @@ class BrowserKitConfig extends AbstractConfig
                 'testHtml5FormMethod',
             ))
             && !method_exists('Symfony\Component\DomCrawler\Tests\FormTest', 'testGetMethodWithOverride')
+            // Symfony 4.4 removed tests from dist archives, making the previous detection return a false-positive
+            && !method_exists('Symfony\Component\DomCrawler\Form', 'getName')
         ) {
             return 'Mink BrowserKit doesn\'t support HTML5 form attributes before Symfony 3.3';
         }


### PR DESCRIPTION
The detection relied on detecting the test method added when introducing the feature in symfony/dom-crawler. But as of Symfony 4.4, tests are stripped from the dist archives. An additional detection based on a new method added in later Symfony version is now used to filter out the false positives (not detecting 4.4 and newer as being <3.3).

This code will be cleaned when dropping support for old Symfony versions, but I want to tag a release before doing that.