### PR TITLE
Delete cookie in subpath correctly

### DIFF
--- a/src/BrowserKitDriver.php
+++ b/src/BrowserKitDriver.php
@@ -273,7 +273,7 @@ class BrowserKitDriver extends CoreDriver
      */
     private function getCookiePath()
     {
-        $path = dirname(parse_url($this->getCurrentUrl(), PHP_URL_PATH));
+        $path = parse_url($this->getCurrentUrl(), PHP_URL_PATH);
 
         if ('\\' === DIRECTORY_SEPARATOR) {
             $path = str_replace('\\', '/', $path);


### PR DESCRIPTION
The `getCookiePath()` function was assuming that the full path name of
the current URL includes the full filename - for example
`/sub-folder/index.php`.

However, where the browser visits the parent folder and the default file
is served (`/sub-folder/` serving `/sub-folder/index.php`) the wrong
current URL is returned.

This means that the deleteCookie function tries to delete for the parent
folder upwards, and where the cookie was set in a specific path, the
delete fails.

For example:

Given a cookie set with:
```
setcookie('somename', 'somevalue', 0, '/some/sub-folder/');
```

The following would fail:
```
$session->visit('/some/sub-folder/');
$session->setCookie('somename', null);
```

The `setCookie` call would call `deleteCookie`, which fetches the URL to
delete. The `getCookiePath()` function would behaved such that:
```
$path = dirname(parse_url($this->getCurrentUrl(), PHP_URL_PATH));
$path = dirname('/some/sub-folder/');
$path = '/some/';
```

Then, when fetching and expiring the cookie on the jar, the path of
`/some/` was used to try and find a cookie located at
`/some/sub-folder/`.

As a result the call to both get and expire the cookie from the jar
would fail as the path was never exact enough.