### PR TITLE
Add a CI job using the HttpBrowser of BrowserKit and HttpClient

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,22 +11,34 @@ defaults:
 jobs:
 
   tests:
-    name: Tests (PHP ${{ matrix.php }} ${{ matrix.minimum_stability }}, Symfony LTS ${{ matrix.symfony_lts }})
+    name: Tests on PHP ${{ matrix.php }} with ${{ matrix.implementation }}${{ matrix.name_suffix }}
     runs-on: ubuntu-20.04
     strategy:
       matrix:
         php: [ '5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1' ]
         minimum_stability: [ 'stable' ]
         symfony_lts: [ false ]
+        name_suffix: [ '' ]
+        implementation: [ 'http_kernel' ]
         include:
           - php: '8.0'
             minimum_stability: dev
+            implementation: 'http_kernel'
+            name_suffix: ' and dev deps'
           - php: '7.4'
             minimum_stability: dev
+            implementation: 'http_kernel'
+            name_suffix: ' and dev deps'
           - php: '7.2'
             symfony_lts: '^2'
+            implementation: 'http_kernel'
+            name_suffix: ' and Symfony 2'
           - php: '7.2'
             symfony_lts: '^3'
+            implementation: 'http_kernel'
+            name_suffix: ' and Symfony 3'
+          - php: '8.0'
+            implementation: http_client
       fail-fast: false
 
     env:
@@ -60,13 +72,35 @@ jobs:
         run: |
           composer require --no-update --dev symfony/error-handler "^4.4 || ^5.0"
 
+      - name: Configure for HttpClient
+        if: "${{ matrix.implementation == 'http_client'}}"
+        run: composer require --no-update --dev symfony/http-client:^4.4 symfony/mime:^4.4
+
       - name: Install dependencies
         run: |
           composer update --no-interaction --prefer-dist
 
+      - name: Setup Mink test server
+        if: "${{ matrix.implementation == 'http_client'}}"
+        run: |
+          mkdir ./logs
+          ./vendor/bin/mink-test-server &> ./logs/mink-test-server.log &
+
+      - name: Wait for browser & PHP to start
+        if: "${{ matrix.implementation == 'http_client'}}"
+        run: |
+          while ! nc -z localhost 8002 </dev/null; do echo Waiting for PHP server to start...; sleep 1; done
+
+
       - name: Run tests
+        if: "${{ matrix.implementation == 'http_kernel'}}"
         run: |
           vendor/bin/phpunit -v --coverage-clover=coverage.clover
+
+      - name: Run tests
+        if: "${{ matrix.implementation == 'http_client'}}"
+        run: |
+          vendor/bin/phpunit -c phpunit.http_client.xml -v --coverage-clover=coverage.clover
 
       - name: Upload code coverage
         if: "${{ matrix.php > '5.4' && matrix.symfony_lts == false }}"

--- a/phpunit.http_client.xml
+++ b/phpunit.http_client.xml
@@ -2,7 +2,7 @@
 
 <phpunit colors="true" bootstrap="vendor/autoload.php">
     <php>
-        <var name="driver_config_factory" value="Behat\Mink\Tests\Driver\HttpKernelBrowserKitConfig::getInstance" />
+        <var name="driver_config_factory" value="Behat\Mink\Tests\Driver\HttpClientBrowserKitConfig::getInstance" />
     </php>
 
     <testsuites>

--- a/src/BrowserKitDriver.php
+++ b/src/BrowserKitDriver.php
@@ -200,12 +200,14 @@ class BrowserKitDriver extends CoreDriver
     {
         if (false === $user) {
             unset($this->serverParameters['PHP_AUTH_USER'], $this->serverParameters['PHP_AUTH_PW']);
+            unset($this->serverParameters['HTTP_AUTHORIZATION']);
 
             return;
         }
 
         $this->serverParameters['PHP_AUTH_USER'] = $user;
         $this->serverParameters['PHP_AUTH_PW'] = $password;
+        $this->serverParameters['HTTP_AUTHORIZATION'] = 'Basic ' . base64_encode($user . ':' . $password);
     }
 
     /**

--- a/tests/AbstractBrowserKitConfig.php
+++ b/tests/AbstractBrowserKitConfig.php
@@ -6,29 +6,11 @@ use Behat\Mink\Driver\BrowserKitDriver;
 use Behat\Mink\Tests\Driver\Util\FixturesKernel;
 use Symfony\Component\HttpKernel\Client;
 
-class BrowserKitConfig extends AbstractConfig
+abstract class AbstractBrowserKitConfig extends AbstractConfig
 {
     public static function getInstance()
     {
-        return new self();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function createDriver()
-    {
-        $client = new Client(new FixturesKernel());
-
-        return new BrowserKitDriver($client);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getWebFixturesUrl()
-    {
-        return 'http://localhost';
+        return new static();
     }
 
     protected function supportsJs()

--- a/tests/HttpClientBrowserKitConfig.php
+++ b/tests/HttpClientBrowserKitConfig.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Behat\Mink\Tests\Driver;
+
+use Behat\Mink\Driver\BrowserKitDriver;
+use Symfony\Component\BrowserKit\HttpBrowser;
+
+class HttpClientBrowserKitConfig extends AbstractBrowserKitConfig
+{
+    public function createDriver()
+    {
+        return new BrowserKitDriver(new HttpBrowser());
+    }
+}

--- a/tests/HttpKernelBrowserKitConfig.php
+++ b/tests/HttpKernelBrowserKitConfig.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Behat\Mink\Tests\Driver;
+
+use Behat\Mink\Driver\BrowserKitDriver;
+use Behat\Mink\Tests\Driver\Util\FixturesKernel;
+use Symfony\Component\HttpKernel\Client;
+
+class HttpKernelBrowserKitConfig extends AbstractBrowserKitConfig
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function createDriver()
+    {
+        $client = new Client(new FixturesKernel());
+
+        return new BrowserKitDriver($client);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getWebFixturesUrl()
+    {
+        return 'http://localhost';
+    }
+}


### PR DESCRIPTION
This BrowserKit implementation is the successor of Goutte (Goutte 4.x is only extending that class under the `Goutte\Client` name without any change). This makes sure we support it.

The new dependencies are not added as dev requirements for now due to the min PHP version (Symfony 4.4 requires PHP 7.1+). This will change once support for those old versions is dropped.