### PR TITLE
Improve the reporting of deprecations in the testsuite

### DIFF
--- a/phpunit.http_client.xml
+++ b/phpunit.http_client.xml
@@ -18,4 +18,8 @@
             <directory>./src</directory>
         </whitelist>
     </filter>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
+    </listeners>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,4 +18,8 @@
             <directory>./src</directory>
         </whitelist>
     </filter>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
+    </listeners>
 </phpunit>

--- a/tests/Custom/ErrorHandlingTest.php
+++ b/tests/Custom/ErrorHandlingTest.php
@@ -175,7 +175,7 @@ class TestClient extends AbstractBrowser
         $this->nextScript = $script;
     }
 
-    protected function doRequest($request)
+    protected function doRequest($request): object
     {
         if (null === $this->nextResponse) {
             return new Response();


### PR DESCRIPTION
When the simple-phpunit script is not used, the test listener is not registered magically by symfony/phpunit-bridge in recent PHPUnit versions. It needs to be registered explicitly.