### PR TITLE
Update the CI setup

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     name: Check composer.json
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: shivammathur/setup-php@v2
         with:
           coverage: none
@@ -25,7 +25,7 @@ jobs:
     name: Static analysis
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: shivammathur/setup-php@v2
         with:
           coverage: none
@@ -36,24 +36,24 @@ jobs:
 
   tests:
     name: Tests on PHP ${{ matrix.php }} with ${{ matrix.implementation }}${{ matrix.name_suffix }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2' ]
+        php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3' ]
         minimum_stability: [ 'stable' ]
         name_suffix: [ '' ]
         implementation: [ 'http_kernel' ]
         include:
-          - php: '8.0'
+          - php: '8.2'
             minimum_stability: dev
             implementation: 'http_kernel'
             name_suffix: ' and dev deps'
-          - php: '7.4'
-            minimum_stability: dev
-            implementation: 'http_kernel'
-            name_suffix: ' and dev deps'
-          - php: '8.0'
+          - php: '8.2'
             implementation: http_client
+          - php: '8.2'
+            minimum_stability: dev
+            implementation: 'http_client'
+            name_suffix: ' and dev deps'
       fail-fast: false
 
     env:
@@ -61,7 +61,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
 


### PR DESCRIPTION
- use latest version of actions/checkout
- add a job for PHP 8.3
- use PHP 8.2 to run the dev deps job (latest versions of our dependencies don't support PHP 8.0 or 7.4 so the previous config was not running against the future version of our dependencies)
- add a job running the dev deps with the http_client implementation as well