### PR TITLE
Throw exception, when doing a "setValue" call on checkbox with a non-boolean value

### DIFF
--- a/src/BrowserKitDriver.php
+++ b/src/BrowserKitDriver.php
@@ -413,6 +413,10 @@ class BrowserKitDriver extends CoreDriver
                 throw new DriverException('Only string values can be used for a radio input.');
             }
 
+            if (!\is_bool($value) && $field->getType() === 'checkbox') {
+                throw new DriverException('Only boolean values can be used for a checkbox input.');
+            }
+
             if (\is_bool($value) && $field->getType() === 'select') {
                 throw new DriverException('Boolean values cannot be used for a select element.');
             }


### PR DESCRIPTION
Fixes a test failure for a test, that is introduced in the https://github.com/minkphp/driver-testsuite/pull/102 .

P.S.
The static analysis failures are unrelated.